### PR TITLE
[WIP] Add PurgeCSS to preset

### DIFF
--- a/src/TailwindCssPreset.php
+++ b/src/TailwindCssPreset.php
@@ -28,6 +28,8 @@ class TailwindCssPreset extends Preset
     {
         return [
             'tailwindcss' => '^0.4.0',
+            'glob-all' => '*',
+            'purgecss-webpack-plugin' => '*'
         ] + Arr::except($packages, ['bootstrap-sass', 'jquery']);
     }
 

--- a/src/tailwindcss-stubs/webpack.mix.js
+++ b/src/tailwindcss-stubs/webpack.mix.js
@@ -1,5 +1,13 @@
 let mix = require('laravel-mix');
 var tailwindcss = require('tailwindcss');
+let glob = require("glob-all");
+let PurgecssPlugin = require("purgecss-webpack-plugin");
+
+class TailwindExtractor {
+  static extract(content) {
+    return content.match(/[A-z0-9-:\/]+/g) || [];
+  }
+}
 
 /*
  |--------------------------------------------------------------------------
@@ -31,3 +39,31 @@ mix.js('resources/assets/js/app.js', 'public/js')
 //       processCssUrls: false,
 //       postCss: [ tailwindcss('tailwind.js') ],
 //    });
+
+// Only run PurgeCSS during production builds for faster development builds
+// and so you still have the full set of utilities available during
+// development.
+if (mix.inProduction()) {
+  mix.webpackConfig({
+    plugins: [
+      new PurgecssPlugin({
+
+        // Specify the locations of any files you want to scan for class names.
+        paths: glob.sync([
+          path.join(__dirname, "resources/views/**/*.blade.php"),
+          path.join(__dirname, "resources/assets/js/**/*.vue")
+        ]),
+        extractors: [
+          {
+            extractor: TailwindExtractor,
+
+            // Specify the file extensions to include when scanning for
+            // class names.
+            extensions: ["html", "js", "php", "vue"]
+          }
+        ]
+      })
+    ]
+  });
+}
+

--- a/src/tailwindcss-stubs/webpack.mix.js
+++ b/src/tailwindcss-stubs/webpack.mix.js
@@ -1,5 +1,5 @@
 let mix = require('laravel-mix');
-var tailwindcss = require('tailwindcss');
+let tailwindcss = require('tailwindcss');
 let glob = require("glob-all");
 let PurgecssPlugin = require("purgecss-webpack-plugin");
 


### PR DESCRIPTION
This modifies the TailwindCSS preset to include PurgeCSS on production builds. Reduces my 110kb Tailwind CSS down to 5kb 😮 

@michaeldyrynda - this is a WIP. It is working (for me) - but I just wanted to put it out there and let some other people try it before you consider merging it in.

I've tested on a Windows 10 Homestead VM - so would be nice for people with Mac's etc to test.