### PR TITLE
Accept flatten resources in L5.7 without breaking backwards compatibility

### DIFF
--- a/src/TailwindCssPreset.php
+++ b/src/TailwindCssPreset.php
@@ -42,23 +42,29 @@ class TailwindCssPreset extends Preset
     protected static function updateStyles()
     {
         tap(new Filesystem, function ($filesystem) {
-            $filesystem->deleteDirectory(resource_path('assets/sass'));
+            $filesystem->deleteDirectory(resource_path(self::flattenPath('sass')));
             $filesystem->delete(public_path('js/app.js'));
             $filesystem->delete(public_path('css/app.css'));
 
-            if (! $filesystem->isDirectory($directory = resource_path('assets/css'))) {
+            if (! $filesystem->isDirectory($directory = resource_path(self::flattenPath('css')))) { 
                 $filesystem->makeDirectory($directory, 0755, true);
             }
         });
 
-        copy(__DIR__.'/tailwindcss-stubs/resources/assets/css/app.css', resource_path('assets/css/app.css'));
+        copy(__DIR__.'/tailwindcss-stubs/resources/assets/css/app.css', resource_path(self::flattenPath('css/app.css')));
     }
 
     protected static function updateBootstrapping()
     {
         copy(__DIR__.'/tailwindcss-stubs/tailwind.js', base_path('tailwind.js'));
-        copy(__DIR__.'/tailwindcss-stubs/webpack.mix.js', base_path('webpack.mix.js'));
-        copy(__DIR__.'/tailwindcss-stubs/resources/assets/js/bootstrap.js', resource_path('assets/js/bootstrap.js'));
+
+        if (self::flattenResources()) {
+            copy(__DIR__.'/tailwindcss-stubs/webpack57.mix.js', base_path('webpack.mix.js'));
+        } else {
+            copy(__DIR__.'/tailwindcss-stubs/webpack.mix.js', base_path('webpack.mix.js'));
+        }
+
+        copy(__DIR__.'/tailwindcss-stubs/resources/assets/js/bootstrap.js', resource_path(self::flattenPath('js/bootstrap.js')));
     }
 
     protected static function updateWelcomePage()
@@ -88,5 +94,15 @@ class TailwindCssPreset extends Preset
             Container::getInstance()->getNamespace(),
             file_get_contents(__DIR__.'/tailwindcss-stubs/controllers/HomeController.stub')
         );
+    }
+
+    private static function flattenResources()
+    {
+        return version_compare(app()->version(), '5.7.0', '>=');
+    }
+
+    private static function flattenPath($path)
+    {
+        return ((self::flattenResources()) ? '' : 'assets/') . $path;
     }
 }

--- a/src/tailwindcss-stubs/webpack57.mix.js
+++ b/src/tailwindcss-stubs/webpack57.mix.js
@@ -1,0 +1,24 @@
+let mix = require("laravel-mix");
+
+require("laravel-mix-tailwind");
+require("laravel-mix-purgecss");
+
+/*
+ |--------------------------------------------------------------------------
+ | Mix Asset Management
+ |--------------------------------------------------------------------------
+ |
+ | Mix provides a clean, fluent API for defining some Webpack build steps
+ | for your Laravel application. By default, we are compiling the Sass
+ | file for the application as well as bundling up all the JS files.
+ |
+ */
+
+mix.js("resources/js/app.js", "public/js")
+   .postCss("resources/css/app.css", "public/css")
+   .tailwind()
+   .purgeCss();
+
+if (mix.inProduction()) {
+  mix.version();
+}


### PR DESCRIPTION
This commit aims to resolve any issues with Laravel's 5.7 flatten resources directory structure without breaking any backwards compatibility. 

https://laravel-news.com/laravel-5-7-resources-directory-changes

It adds 2 static functions to the preset file. The first function `flattenResources()` returns true if the detected app version is 5.7.0 or greater and false if not. This allows us to switch between the flatten structure or the previous directory structure.

```php
    private static function flattenResources()
    {
        return version_compare(app()->version(), '5.7.0', '>=');
    }
```

The second utility function it adds is a quick path generator function that accepts a path and using `flattenResources()` returns the appropriate directory structure to the given path.

```php
    private static function flattenPath($path)
    {
        return ((self::flattenResources()) ? '' : 'assets/') . $path;
    }
```

Finally, I have added a secondary `webpack.mix.js` file named `webpack57.mix.js` allowing us to set the appropriate directory structures in these files for Laravel 5.7 without breaking backwards compatibility.

Has been tested on a 5.6.36 virgin and on a dev-master project.