### PR TITLE
Patches paths & views to match laravel 5.7 style

### DIFF
--- a/src/TailwindCssPreset.php
+++ b/src/TailwindCssPreset.php
@@ -42,23 +42,23 @@ class TailwindCssPreset extends Preset
     protected static function updateStyles()
     {
         tap(new Filesystem, function ($filesystem) {
-            $filesystem->deleteDirectory(resource_path('assets/sass'));
+            $filesystem->deleteDirectory(resource_path('sass'));
             $filesystem->delete(public_path('js/app.js'));
             $filesystem->delete(public_path('css/app.css'));
 
-            if (! $filesystem->isDirectory($directory = resource_path('assets/css'))) {
+            if (! $filesystem->isDirectory($directory = resource_path('css'))) {
                 $filesystem->makeDirectory($directory, 0755, true);
             }
         });
 
-        copy(__DIR__.'/tailwindcss-stubs/resources/assets/css/app.css', resource_path('assets/css/app.css'));
+        copy(__DIR__.'/tailwindcss-stubs/resources/assets/css/app.css', resource_path('css/app.css'));
     }
 
     protected static function updateBootstrapping()
     {
         copy(__DIR__.'/tailwindcss-stubs/tailwind.js', base_path('tailwind.js'));
         copy(__DIR__.'/tailwindcss-stubs/webpack.mix.js', base_path('webpack.mix.js'));
-        copy(__DIR__.'/tailwindcss-stubs/resources/assets/js/bootstrap.js', resource_path('assets/js/bootstrap.js'));
+        copy(__DIR__.'/tailwindcss-stubs/resources/assets/js/bootstrap.js', resource_path('js/bootstrap.js'));
     }
 
     protected static function updateWelcomePage()

--- a/src/tailwindcss-stubs/resources/assets/js/bootstrap.js
+++ b/src/tailwindcss-stubs/resources/assets/js/bootstrap.js
@@ -38,5 +38,7 @@ if (token) {
 
 // window.Echo = new Echo({
 //     broadcaster: 'pusher',
-//     key: 'your-pusher-key'
+//     key: process.env.MIX_PUSHER_APP_KEY,
+//     cluster: process.env.MIX_PUSHER_APP_CLUSTER,
+//     encrypted: true
 // });

--- a/src/tailwindcss-stubs/resources/views/auth/login.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/login.blade.php
@@ -5,14 +5,14 @@
     <div class="w-full max-w-md md:mx-auto">
         <div class="rounded shadow">
             <div class="font-medium text-lg text-teal-darker bg-teal p-3 rounded-t">
-                Login
+                {{ __('Login') }}
             </div>
             <div class="bg-white p-3 rounded-b">
-                <form class="form-horizontal" method="POST" action="{{ route('login') }}">
-                    {{ csrf_field() }}
+                <form method="POST" action="{{ route('login') }}">
+                    @csrf
 
                     <div class="flex items-stretch mb-3">
-                        <label for="email" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">E-Mail Address</label>
+                        <label for="email" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">{{ __('E-Mail Address') }}</label>
                         <div class="flex flex-col w-3/4">
                             <input id="email" type="email" class="flex-grow h-8 px-2 border rounded {{ $errors->has('email') ? 'border-red-dark' : 'border-grey-light' }}" name="email" value="{{ old('email') }}" required autofocus>
                             {!! $errors->first('email', '<span class="text-red-dark text-sm mt-2">:message</span>') !!}
@@ -20,7 +20,7 @@
                     </div>
 
                     <div class="flex items-stretch mb-4">
-                        <label for="password" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">Password</label>
+                        <label for="password" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">{{ __('Password') }}</label>
                         <div class="flex flex-col w-3/4">
                             <input id="password" type="password" class="flex-grow h-8 px-2 rounded border {{ $errors->has('password') ? 'border-red-dark' : 'border-grey-light' }}" name="password" required>
                             {!! $errors->first('password', '<span class="text-red-dark text-sm mt-2">:message</span>') !!}
@@ -29,17 +29,17 @@
 
                     <div class="flex mb-4">
                         <label class="w-3/4 ml-auto">
-                            <input type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}> <span class="text-sm text-grey-dark"> Remember Me</span>
+                            <input type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}> <span class="text-sm text-grey-dark">{{ __('Remember Me') }}</span>
                         </label>
                     </div>
 
                     <div class="flex">
                         <div class="w-3/4 ml-auto">
                             <button type="submit" class="bg-teal hover:bg-teal-dark text-white text-sm font-semibold py-2 px-4 rounded mr-3">
-                                Login
+                                {{ __('Login') }}
                             </button>
                             <a class="no-underline hover:underline text-teal-darker text-sm" href="{{ route('password.request') }}">
-                                Forgot Your Password?
+                                {{ __('Forgot Your Password?') }}
                             </a>
                         </div>
                     </div>

--- a/src/tailwindcss-stubs/resources/views/auth/passwords/email.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/passwords/email.blade.php
@@ -5,20 +5,20 @@
     <div class="md:w-1/2 md:mx-auto">
         <div class="rounded shadow">
             <div class="font-medium text-lg text-teal-darker bg-teal p-3 rounded-t">
-                Reset Password
+                {{ __('Reset Password') }}
             </div>
             <div class="bg-white p-3 rounded-b">
                 @if (session('status'))
-                    <div class="bg-green-lightest border border-green-light text-green-dark text-sm px-4 py-3 rounded mb-4">
+                    <div class="bg-green-lightest border border-green-light text-green-dark text-sm px-4 py-3 rounded mb-4" role="alert">
                         {{ session('status') }}
                     </div>
                 @endif
 
-                <form class="form-horizontal" method="POST" action="{{ route('password.email') }}">
-                    {{ csrf_field() }}
+                <form method="POST" action="{{ route('password.email') }}">
+                    @csrf
 
                     <div class="flex items-stretch mb-3">
-                        <label for="email" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">E-Mail Address</label>
+                        <label for="email" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">{{ __('E-Mail Address') }}</label>
                         <div class="flex flex-col w-3/4">
                             <input id="email" type="email" class="flex-grow h-8 px-2 border rounded {{ $errors->has('email') ? 'border-red-dark' : 'border-grey-light' }}" name="email" value="{{ old('email') }}" required autofocus>
                             {!! $errors->first('email', '<span class="text-red-dark text-sm mt-2">:message</span>') !!}
@@ -28,7 +28,7 @@
                     <div class="flex">
                         <div class="w-3/4 ml-auto">
                             <button type="submit" class="bg-teal hover:bg-teal-dark text-white text-sm font-semibold py-2 px-4 rounded mr-3">
-                                Send Password Reset Link
+                                {{ __('Send Password Reset Link') }}
                             </button>
                         </div>
                     </div>

--- a/src/tailwindcss-stubs/resources/views/auth/passwords/reset.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/passwords/reset.blade.php
@@ -5,16 +5,16 @@
     <div class="md:w-1/2 md:mx-auto">
         <div class="rounded shadow">
             <div class="font-medium text-lg text-teal-darker bg-teal p-3 rounded-t">
-                Reset Password
+                {{ __('Reset Password') }}
             </div>
             <div class="bg-white p-3 rounded-b">
-                <form class="form-horizontal" method="POST" action="{{ route('password.request') }}">
-                    {{ csrf_field() }}
+                <form method="POST" action="{{ route('password.request') }}">
+                    @csrf
 
                     <input type="hidden" name="token" value="{{ $token }}">
 
                     <div class="flex items-stretch mb-3">
-                        <label for="email" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">E-Mail Address</label>
+                        <label for="email" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">{{ __('E-Mail Address') }}</label>
                         <div class="flex flex-col w-3/4">
                             <input id="email" type="email" class="flex-grow h-8 px-2 border rounded {{ $errors->has('email') ? 'border-red-dark' : 'border-grey-light' }}" name="email" value="{{ $email or old('email') }}" required autofocus>
                             {!! $errors->first('email', '<span class="text-red-dark text-sm mt-2">:message</span>') !!}
@@ -22,7 +22,7 @@
                     </div>
 
                     <div class="flex items-stretch mb-3">
-                        <label for="password" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">Password</label>
+                        <label for="password" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">{{ __('Password') }}</label>
                         <div class="flex flex-col w-3/4">
                             <input id="password" type="password" class="flex-grow h-8 px-2 rounded border {{ $errors->has('password') ? 'border-red-dark' : 'border-grey-light' }}" name="password" required>
                             {!! $errors->first('password', '<span class="text-red-dark text-sm mt-2">:message</span>') !!}
@@ -30,7 +30,7 @@
                     </div>
 
                     <div class="flex items-stretch mb-3">
-                        <label for="password_confirmation" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">Confirm Password</label>
+                        <label for="password_confirmation" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">{{ __('Confirm Password') }}</label>
                         <div class="flex flex-col w-3/4">
                             <input id="password_confirmation" type="password" class="flex-grow h-8 px-2 rounded border {{ $errors->has('password_confirmation') ? 'border-red-dark' : 'border-grey-light' }}" name="password_confirmation" required>
                             {!! $errors->first('password_confirmation', '<span class="text-red-dark text-sm mt-2">:message</span>') !!}
@@ -40,7 +40,7 @@
                     <div class="flex">
                         <div class="w-3/4 ml-auto">
                             <button type="submit" class="bg-teal hover:bg-teal-dark text-white text-sm font-semibold py-2 px-4 rounded mr-3">
-                                Reset Password
+                                {{ __('Reset Password') }}
                             </button>
                         </div>
                     </div>

--- a/src/tailwindcss-stubs/resources/views/auth/register.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/register.blade.php
@@ -5,14 +5,14 @@
     <div class="w-full max-w-md md:mx-auto">
         <div class="rounded shadow">
             <div class="font-medium text-lg text-teal-darker bg-teal p-3 rounded-t">
-                Register
+                {{ __('Register') }}
             </div>
             <div class="bg-white p-3 rounded-b">
                 <form class="form-horizontal" method="POST" action="{{ route('register') }}">
-                    {{ csrf_field() }}
+                    @csrf
 
                     <div class="flex items-stretch mb-3">
-                        <label for="name" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">Name</label>
+                        <label for="name" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">{{ __('Name') }}</label>
                         <div class="flex flex-col w-3/4">
                             <input id="name" type="text" class="flex-grow h-8 px-2 border rounded {{ $errors->has('name') ? 'border-red-dark' : 'border-grey-light' }}" name="name" value="{{ old('name') }}" autofocus>
                             {!! $errors->first('name', '<span class="text-red-dark text-sm mt-2">:message</span>') !!}
@@ -20,7 +20,7 @@
                     </div>
 
                     <div class="flex items-stretch mb-3">
-                        <label for="email" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">E-Mail Address</label>
+                        <label for="email" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">{{ __('E-Mail Address') }}</label>
                         <div class="flex flex-col w-3/4">
                             <input id="email" type="email" class="flex-grow h-8 px-2 border rounded {{ $errors->has('email') ? 'border-red-dark' : 'border-grey-light' }}" name="email" value="{{ old('email') }}" required>
                             {!! $errors->first('email', '<span class="text-red-dark text-sm mt-2">:message</span>') !!}
@@ -28,7 +28,7 @@
                     </div>
 
                     <div class="flex items-stretch mb-4">
-                        <label for="password" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">Password</label>
+                        <label for="password" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">{{ __('Password') }}</label>
                         <div class="flex flex-col w-3/4">
                             <input id="password" type="password" class="flex-grow h-8 px-2 rounded border {{ $errors->has('password') ? 'border-red-dark' : 'border-grey-light' }}" name="password" required>
                             {!! $errors->first('password', '<span class="text-red-dark text-sm mt-2">:message</span>') !!}
@@ -36,7 +36,7 @@
                     </div>
 
                     <div class="flex items-stretch mb-4">
-                        <label for="password_confirmation" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">Confirm Password</label>
+                        <label for="password_confirmation" class="text-right font-semibold text-grey-dark text-sm pt-2 pr-3 align-middle w-1/4">{{ __('Confirm Password') }}</label>
                         <div class="flex flex-col w-3/4">
                             <input id="password_confirmation" type="password" class="flex-grow h-8 px-2 rounded border {{ $errors->has('password_confirmation') ? 'border-red-dark' : 'border-grey-light' }}" name="password_confirmation" required>
                             {!! $errors->first('password_confirmation', '<span class="text-red-dark text-sm mt-2">:message</span>') !!}
@@ -46,7 +46,7 @@
                     <div class="flex">
                         <div class="w-3/4 ml-auto">
                             <button type="submit" class="bg-teal hover:bg-teal-dark text-white text-sm font-semibold py-2 px-4 rounded mr-3">
-                                Register
+                                {{ __('Register') }}
                             </button>
                         </div>
                     </div>

--- a/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="flex items-center px-6 md:px-0">
+    <div class="w-full max-w-md md:mx-auto">
+        <div class="rounded shadow">
+            <div class="font-medium text-lg text-teal-darker bg-teal p-3 rounded-t">
+                {{ __('Verify Your Email Address') }}
+            </div>
+            <div class="bg-white p-3 rounded-b">
+                @if (session('resent'))
+                    <div class="bg-green-lightest border border-green-light text-green-dark text-sm px-4 py-3 rounded mb-4" role="alert">
+                        {{ __('A fresh verification link has been sent to your email address.') }}
+                    </div>
+                @endif
+
+                {{ __('Before proceeding, please check your email for a verification link.') }}
+                {{ __('If you did not receive the email') }}, <a href="{{ route('verification.resend') }}">{{ __('click here to request another') }}</a>.
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/src/tailwindcss-stubs/resources/views/layouts/app.blade.php
+++ b/src/tailwindcss-stubs/resources/views/layouts/app.blade.php
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
-<html lang="{{ app()->getLocale() }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- CSRF Token -->
@@ -25,17 +24,17 @@
                     </div>
                     <div class="flex-1 text-right">
                         @guest
-                            <a class="no-underline hover:underline text-teal-darker pr-3 text-sm" href="{{ url('/login') }}">Login</a>
-                            <a class="no-underline hover:underline text-teal-darker text-sm" href="{{ url('/register') }}">Register</a>
+                            <a class="no-underline hover:underline text-teal-darker pr-3 text-sm" href="{{ route('login') }}">{{ __('Login') }}</a>
+                            <a class="no-underline hover:underline text-teal-darker text-sm" href="{{ route('register') }}">{{ __('Register') }}</a>
                         @else
                             <span class="text-teal-darker text-sm pr-4">{{ Auth::user()->name }}</span>
 
                             <a href="{{ route('logout') }}"
                                 class="no-underline hover:underline text-teal-darker text-sm"
                                 onclick="event.preventDefault();
-                                document.getElementById('logout-form').submit();">Logout</a>
+                                document.getElementById('logout-form').submit();">{{ __('Logout') }}</a>
                             <form id="logout-form" action="{{ route('logout') }}" method="POST" class="hidden">
-                                {{ csrf_field() }}
+                                @csrf
                             </form>
                         @endguest
                     </div>

--- a/src/tailwindcss-stubs/resources/views/welcome.blade.php
+++ b/src/tailwindcss-stubs/resources/views/welcome.blade.php
@@ -43,6 +43,9 @@
                             <a href="https://laravel-news.com" class="no-underline hover:underline text-sm font-normal text-teal-darker uppercase" title="News">News</a>
                         </li>
                         <li class="inline pr-8">
+                            <a href="https://nova.laravel.com" class="no-underline hover:underline text-sm font-normal text-teal-darker uppercase" title="Nova">Nova</a>
+                        </li>
+                        <li class="inline pr-8">
                             <a href="https://forge.laravel.com" class="no-underline hover:underline text-sm font-normal text-teal-darker uppercase" title="Forge">Forge</a>
                         </li>
                         <li class="inline pr-8">

--- a/src/tailwindcss-stubs/webpack.mix.js
+++ b/src/tailwindcss-stubs/webpack.mix.js
@@ -14,8 +14,8 @@ require("laravel-mix-purgecss");
  |
  */
 
-mix.js("resources/assets/js/app.js", "public/js")
-   .postCss("resources/assets/css/app.css", "public/css")
+mix.js("resources/js/app.js", "public/js")
+   .postCss("resources/css/app.css", "public/css")
    .tailwind()
    .purgeCss();
 

--- a/src/tailwindcss-stubs/webpack.mix.js
+++ b/src/tailwindcss-stubs/webpack.mix.js
@@ -1,4 +1,4 @@
-let mix = require("laravel-mix");
+const mix = require("laravel-mix");
 
 require("laravel-mix-tailwind");
 require("laravel-mix-purgecss");


### PR DESCRIPTION
Given Laravel 5.7 changed its assets path from `resources/assets` to `resources` this package is failing and not providing a complete preset for the laravel 5.7 version 

I am not so sure how should be handled the versioning control because this would break in lower laravel versions.

I think it is a good start for the upgrade path, but not so sure on how to continue

+ Views are also updated to mimic the latests stubs in the official laravel repository. 
+ New `verify.blade.php` is also added