### PR TITLE
bumps laravel-mix to 4 and laravel-mix-purgecss to 4.1

### DIFF
--- a/src/TailwindCssPreset.php
+++ b/src/TailwindCssPreset.php
@@ -27,8 +27,8 @@ class TailwindCssPreset extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return array_merge([
-            'laravel-mix' => '^2.1',
-            'laravel-mix-purgecss' => '^2.2',
+            'laravel-mix' => '^4.0.14',
+            'laravel-mix-purgecss' => '^4.1',
             'laravel-mix-tailwind' => '^0.1.0',
         ], Arr::except($packages, [
             'bootstrap',


### PR DESCRIPTION
This PR updates the package.json to use current versions of laravel-mix and laravel-mix-purgecsss.

In fresh installations of Laravel the following boilerplate is used:

`Vue.component('example-component', require('./components/ExampleComponent').default);`

The `.default` results in a compile error with laravel-mix 2 because this syntax is used by babel 6 (I believe). No error with laravel-mix 4