### PR TITLE
Check for register route

### DIFF
--- a/src/tailwindcss-stubs/resources/views/auth/login.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/login.blade.php
@@ -60,12 +60,14 @@
                                 </a>
                             @endif
 
-                            <p class="w-full text-xs text-center text-grey-dark mt-8 -mb-4">
-                                Don't have an account?
-                                <a class="text-blue hover:text-blue-dark no-underline" href="{{ route('register') }}">
-                                    Register
-                                </a>
-                            </p>
+                            @if (Route::has('register'))
+                                <p class="w-full text-xs text-center text-grey-dark mt-8 -mb-4">
+                                    Don't have an account?
+                                    <a class="text-blue hover:text-blue-dark no-underline" href="{{ route('register') }}">
+                                        Register
+                                    </a>
+                                </p>
+                            @endif
                         </div>
                     </form>
 

--- a/src/tailwindcss-stubs/resources/views/layouts/app.blade.php
+++ b/src/tailwindcss-stubs/resources/views/layouts/app.blade.php
@@ -25,7 +25,9 @@
                     <div class="flex-1 text-right">
                         @guest
                             <a class="no-underline hover:underline text-grey-lightest text-sm p-3" href="{{ route('login') }}">{{ __('Login') }}</a>
-                            <a class="no-underline hover:underline text-grey-lightest text-sm p-3" href="{{ route('register') }}">{{ __('Register') }}</a>
+                            @if (Route::has('register'))
+                                <a class="no-underline hover:underline text-grey-lightest text-sm p-3" href="{{ route('register') }}">{{ __('Register') }}</a>
+                            @endif
                         @else
                             <span class="text-grey-lightest text-sm pr-4">{{ Auth::user()->name }}</span>
 

--- a/src/tailwindcss-stubs/resources/views/welcome.blade.php
+++ b/src/tailwindcss-stubs/resources/views/welcome.blade.php
@@ -21,7 +21,9 @@
                 <a href="{{ url('/home') }}" class="no-underline hover:underline text-sm font-normal text-teal-darker uppercase">{{ __('Home') }}</a>
             @else
                 <a href="{{ route('login') }}" class="no-underline hover:underline text-sm font-normal text-teal-darker uppercase pr-6">{{ __('Login') }}</a>
-                <a href="{{ route('register') }}" class="no-underline hover:underline text-sm font-normal text-teal-darker uppercase">{{ __('Register') }}</a>
+                @if (Route::has('register'))
+                    <a href="{{ route('register') }}" class="no-underline hover:underline text-sm font-normal text-teal-darker uppercase">{{ __('Register') }}</a>
+                @endif
             @endauth
         </div>
     @endif


### PR DESCRIPTION
As of Laravel 5.7.3 user can disable register route with simple `Auth::routes(['register' => false]).`

Because of this is smart to check if the router has register route. This prevents `Route [register] not defined.` errors.