### PR TITLE
Consistent colour for error messages

### DIFF
--- a/src/tailwindcss-stubs/resources/views/auth/passwords/email.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/passwords/email.blade.php
@@ -28,7 +28,7 @@
                             <input id="email" type="email" class="shadow appearance-none border rounded w-full py-2 px-3 text-grey-darker leading-tight focus:outline-none focus:shadow-outline{{ $errors->has('email') ? ' border-red' : '' }}" name="email" value="{{ old('email') }}" required>
 
                             @if ($errors->has('email'))
-                                <p class="text-red-100 text-xs italic mt-4">
+                                <p class="text-red-500 text-xs italic mt-4">
                                     {{ $errors->first('email') }}
                                 </p>
                             @endif


### PR DESCRIPTION
Noticed this one error used `text-red-100` where the rest were `text-red-500`. 

It was so light it was basically invisible.