### PR TITLE
Move purge css call to production only

### DIFF
--- a/src/tailwindcss-stubs/webpack.mix.js
+++ b/src/tailwindcss-stubs/webpack.mix.js
@@ -16,9 +16,10 @@ require('laravel-mix-purgecss');
 
 mix.js('resources/js/app.js', 'public/js')
    .postCss('resources/css/app.css', 'public/css')
-   .tailwind('./tailwind.config.js')
-   .purgeCss();
+   .tailwind('./tailwind.config.js');
 
 if (mix.inProduction()) {
-  mix.version();
+  mix
+   .version()
+   .purgeCss();
 }


### PR DESCRIPTION
PurgeCss calls should be made only in production environments, during development if you're using any running `npm run watch` or `npm run hot` you're going to strip out classes that you could be adding to your project.