### PR TITLE
add translation helper to new strings

### DIFF
--- a/src/tailwindcss-stubs/resources/views/auth/login.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/login.blade.php
@@ -62,9 +62,9 @@
 
                             @if (Route::has('register'))
                                 <p class="w-full text-xs text-center text-gray-700 mt-8 -mb-4">
-                                    Don't have an account?
+                                    {{ __("Don't have an account?") }}
                                     <a class="text-blue-500 hover:text-blue-700 no-underline" href="{{ route('register') }}">
-                                        Register
+                                        {{ __('Register') }}
                                     </a>
                                 </p>
                             @endif

--- a/src/tailwindcss-stubs/resources/views/auth/passwords/email.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/passwords/email.blade.php
@@ -41,7 +41,7 @@
 
                             <p class="w-full text-xs text-center text-grey-dark mt-8 -mb-4">
                                 <a class="text-blue-500 hover:text-blue-700 no-underline" href="{{ route('login') }}">
-                                    Back to login
+                                    {{ __('Back to login') }}
                                 </a>
                             </p>
                         </div>

--- a/src/tailwindcss-stubs/resources/views/auth/register.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/register.blade.php
@@ -69,9 +69,9 @@
                             </button>
 
                             <p class="w-full text-xs text-center text-gray-700 mt-8 -mb-4">
-                                Already have an account?
+                                {{ __('Already have an account?') }}
                                 <a class="text-blue-500 hover:text-blue-700 no-underline" href="{{ route('login') }}">
-                                    Login
+                                    {{ __('Login') }}
                                 </a>
                             </p>
                         </div>


### PR DESCRIPTION
Some recently added string were not using the `__()` translation helper, so they are not translatable out of the box.