### PR TITLE
Fixes the word from the verify email sentence

### DIFF
--- a/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
@@ -22,7 +22,7 @@
                         </p>
 
                         <p class="leading-normal mt-6">
-                            {{ __('If you did not receive the email') }}, <a class="text-blue-500 hover:text-blue-700 no-underline" onclick="event.preventDefault(); document.getElementById('resend-verification-form').submit();">{{ __('click here to resend another') }}</a>.
+                            {{ __('If you did not receive the email') }}, <a class="text-blue-500 hover:text-blue-700 no-underline" onclick="event.preventDefault(); document.getElementById('resend-verification-form').submit();">{{ __('click here to request another') }}</a>.
                         </p>
 
                         <form id="resend-verification-form" method="POST" action="{{ route('verification.resend') }}" class="hidden">


### PR DESCRIPTION
Simple fix to stay in sync with the sentence used in the official [Laravel UI file](https://github.com/laravel/ui/blob/master/src/Auth/bootstrap-stubs/auth/verify.stub#L21).