### PR TITLE
Added a theme file for the confirm password route that got added in

### DIFF
--- a/src/tailwindcss-stubs/resources/views/auth/passwords/confirm.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/passwords/confirm.blade.php
@@ -1,0 +1,51 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container mx-auto">
+        <div class="flex flex-wrap justify-center">
+            <div class="w-full max-w-sm">
+                <div class="flex flex-col break-words bg-white border border-2 rounded shadow-md">
+
+                    <div class="font-semibold bg-gray-200 text-gray-700 py-3 px-6 mb-0">
+                        {{ __('Confirm Password') }}
+                    </div>
+
+                    <form class="w-full p-6" method="POST" action="{{ route('password.confirm') }}">
+                        @csrf
+
+                        <p class="leading-normal">
+                            {{ __('Please confirm your password before continuing.') }}
+                        </p>
+
+                        <div class="flex flex-wrap my-6">
+                            <label for="password" class="block text-gray-700 text-sm font-bold mb-2">
+                                {{ __('Password') }}:
+                            </label>
+
+                            <input id="password" type="password" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline @error('password') border-red-500 @enderror" name="password" required autocomplete="new-password">
+
+                            @error('password')
+                                <p class="text-red-500 text-xs italic mt-4">
+                                    {{ $message }}
+                                </p>
+                            @enderror
+                        </div>
+
+                        <div class="flex flex-wrap items-center">
+                            <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-gray-100 font-bold  py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+                                {{ __('Confirm Password') }}
+                            </button>
+
+                            @if (Route::has('password.request'))
+                                <a class="text-sm text-blue-500 hover:text-blue-700 whitespace-no-wrap no-underline ml-auto" href="{{ route('password.request') }}">
+                                    {{ __('Forgot Your Password?') }}
+                                </a>
+                            @endif
+                        </div>
+                    </form>
+
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection


### PR DESCRIPTION
Create a themed `confirm.blade.php` to suppose the `password.confirm` middleware that got added in Laravel 6.

To test this login to your Laravel 6 app and visit a page with that middleware registered. 

```php
Route::get('/test', function () {
    return view('welcome');
})->middleware('password.confirm');
```

This will block the given route until the correct password is entered.

![confirm_password](https://user-images.githubusercontent.com/401672/68005719-41db5f80-fcca-11e9-8d79-b56a6ac6df15.png)
