### PR TITLE
Reference to base stylesheet in comment for "@tailwind base"

### DIFF
--- a/src/tailwindcss-stubs/resources/css/app.css
+++ b/src/tailwindcss-stubs/resources/css/app.css
@@ -3,7 +3,7 @@
  * Normalize.css and some additional base styles.
  *
  * You can see the styles here:
- * https://github.com/tailwindcss/tailwindcss/blob/master/css/base.css
+ * https://unpkg.com/tailwindcss/dist/base.css
  *
  * If using `postcss-import`, use this import instead:
  *


### PR DESCRIPTION
specified gh link does not exist anymore. Changed to the one that is referred from the docs (https://tailwindcss.com/docs/preflight/)