### PR TITLE
Correctly call the tailwindcss preset if the auth flag is not passed

### DIFF
--- a/src/TailwindCssPreset.php
+++ b/src/TailwindCssPreset.php
@@ -23,7 +23,6 @@ class TailwindCssPreset extends Preset
 
     public static function installAuth()
     {
-        static::install();
         static::scaffoldController();
         static::scaffoldAuth();
     }

--- a/src/TailwindCssPresetServiceProvider.php
+++ b/src/TailwindCssPresetServiceProvider.php
@@ -14,14 +14,11 @@ class TailwindCssPresetServiceProvider extends ServiceProvider
         UiCommand::macro('tailwindcss', function ($command) {
             TailwindCssPreset::install();
 
+            if ( $command->option('auth') ) {
+                TailwindCssPreset::installAuth();
+            }
+
             $command->info('Tailwind CSS scaffolding installed successfully.');
-            $command->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
-        });
-
-        AuthCommand::macro('tailwindcss', function ($command) {
-            TailwindCssPreset::installAuth();
-
-            $command->info('Tailwind CSS scaffolding with auth views installed successfully.');
             $command->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
         });
 


### PR DESCRIPTION
Due to the removal of `tailwindcss-auth` macro the `tailwindcss` macro
will always run `TailwindCssPreset::installAuth()`. This is in large
part because how macro's work and the `UiCommand::macro('tailwindcss')`
getting overwritten by `AuthCommand::macro('tailwindcss')`.

This commit assumes that just having one macro of `tailwindcss` is the
acceptable use moving forward. With that said, this commit check the
command option auth flag and if it's true will correctly install all the
auth presets.

This commit also removes the call to the `install()` method on the
TailwindCssPreset::installAuth method as this should always be called on
the macro.

![image](https://user-images.githubusercontent.com/337947/76029691-fe586280-5f02-11ea-81b8-1a72dad6d3cf.png)
