### PR TITLE
Add tailwindcss-auth command back to the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Laravel front-end scaffolding preset for [Tailwind CSS](https://tailwindcss.co
 
 ### b. For Presets with Authentication
 
-1. Use `php artisan ui tailwindcss --auth` for the basic preset, auth route entry and Tailwind CSS auth views in one go. (NOTE: If you run this command several times, be sure to clean up the duplicate Auth entries in `routes/web.php`)
+1. Use `php artisan ui tailwindcss-auth` for the basic preset, auth route entry and Tailwind CSS auth views in one go. (NOTE: If you run this command several times, be sure to clean up the duplicate Auth entries in `routes/web.php`)
 4. `npm install && npm run dev`
 5. Configure your favorite database (mysql, sqlite etc.)
 6. `php artisan migrate` to create basic user tables.

--- a/src/TailwindCssPresetServiceProvider.php
+++ b/src/TailwindCssPresetServiceProvider.php
@@ -18,7 +18,7 @@ class TailwindCssPresetServiceProvider extends ServiceProvider
             $command->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
         });
 
-        AuthCommand::macro('tailwindcss', function ($command) {
+        AuthCommand::macro('tailwindcss-auth', function ($command) {
             TailwindCssPreset::installAuth();
 
             $command->info('Tailwind CSS scaffolding with auth views installed successfully.');


### PR DESCRIPTION
Due to some issues with how macros work the `AuthCommand::macro` was
overwriting the standard `UiCommand::macro`.  This commit adds the
`tailwindcss-auth` back.