### PR TITLE
[bugfix] Anchor is not having pointer cursor on verification resend link

### DIFF
--- a/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
@@ -22,7 +22,7 @@
                         </p>
 
                         <p class="leading-normal mt-6">
-                            {{ __('If you did not receive the email') }}, <a class="text-blue-500 hover:text-blue-700 no-underline" onclick="event.preventDefault(); document.getElementById('resend-verification-form').submit();">{{ __('click here to request another') }}</a>.
+                            {{ __('If you did not receive the email') }}, <a class="text-blue-500 hover:text-blue-700 no-underline cursor-pointer" onclick="event.preventDefault(); document.getElementById('resend-verification-form').submit();">{{ __('click here to request another') }}</a>.
                         </p>
 
                         <form id="resend-verification-form" method="POST" action="{{ route('verification.resend') }}" class="hidden">


### PR DESCRIPTION
The anchor tag has a `preventDefault()` and no `href` attribute, so the hover pointer is the text cursor, not the pointer one. This should fix it.

I have re-checked all of the other links and this is the only occurence.

![bar](https://user-images.githubusercontent.com/21983456/82350685-58e26480-9a04-11ea-9f43-83db4db07286.png)
