### PR TITLE
Use PostCSS directly and include Tailwind UI

### DIFF
--- a/src/TailwindCssPreset.php
+++ b/src/TailwindCssPreset.php
@@ -30,10 +30,13 @@ class TailwindCssPreset extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return array_merge([
+            '@tailwindcss/ui' => '^0.3',
+            'autoprefixer' => '^9.6',
             'laravel-mix' => '^5.0.1',
-            'laravel-mix-tailwind' => '^0.1.0',
+            'postcss-import' => '^12.0',
+            'postcss-nested' => '^4.2',
             'tailwindcss' => '^1.4',
-            '@tailwindcss/custom-forms' => '^0.2',
+            'vue-template-compiler' => '^2.6.11',
         ], Arr::except($packages, [
             'bootstrap',
             'bootstrap-sass',

--- a/src/tailwindcss-stubs/resources/css/app.css
+++ b/src/tailwindcss-stubs/resources/css/app.css
@@ -1,5 +1,5 @@
-@tailwind base;
+@import "tailwindcss/base";
 
-@tailwind components;
+@import "tailwindcss/components";
 
-@tailwind utilities;
+@import "tailwindcss/utilities";

--- a/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
@@ -22,7 +22,7 @@
                         </p>
 
                         <p class="leading-normal mt-6">
-                            {{ __('If you did not receive the email') }}, <a class="text-blue-500 hover:text-blue-700 no-underline" onclick="event.preventDefault(); document.getElementById('resend-verification-form').submit();">{{ __('click here to request another') }}</a>.
+                            {{ __('If you did not receive the email') }}, <a class="text-blue-500 hover:text-blue-700 no-underline cursor-pointer" onclick="event.preventDefault(); document.getElementById('resend-verification-form').submit();">{{ __('click here to request another') }}</a>.
                         </p>
 
                         <form id="resend-verification-form" method="POST" action="{{ route('verification.resend') }}" class="hidden">

--- a/src/tailwindcss-stubs/tailwind.config.js
+++ b/src/tailwindcss-stubs/tailwind.config.js
@@ -8,6 +8,6 @@ module.exports = {
   },
   variants: {},
   plugins: [
-    require('@tailwindcss/custom-forms')
+    require('@tailwindcss/ui'),
   ]
 }

--- a/src/tailwindcss-stubs/webpack.mix.js
+++ b/src/tailwindcss-stubs/webpack.mix.js
@@ -1,7 +1,5 @@
 const mix = require('laravel-mix');
 
-require('laravel-mix-tailwind');
-
 /*
  |--------------------------------------------------------------------------
  | Mix Asset Management
@@ -14,8 +12,12 @@ require('laravel-mix-tailwind');
  */
 
 mix.js('resources/js/app.js', 'public/js')
-   .postCss('resources/css/app.css', 'public/css')
-   .tailwind('./tailwind.config.js');
+   .postCss('resources/css/app.css', 'public/css', [
+      require('postcss-import'),
+      require('tailwindcss'),
+      require('postcss-nested'),
+      require('autoprefixer'),
+  ]);
 
 if (mix.inProduction()) {
   mix


### PR DESCRIPTION
Hey, thanks for creating the preset. I'd like to propose some changes in how Tailwind is referenced.

Following Adam's [Tailwind CSS Best Practice Patterns](https://www.youtube.com/watch?v=J_7_mnFSLDg) I found quite interesting the use of `postcss-import` and `postcss-nested`. I think they might be useful as a default. Doing so I removed `laravel-mix-tailwind` and added the plugins directly to the Laravel Mix `postCss` method call.

I also included `tailwindcss/ui` as a default instead of `tailwindcss/custom-forms` to let everyone use the new defaults they introduced.

Let me know if these changes make sense for the preset.