### PR TITLE
Remove redundant border classes

### DIFF
--- a/src/tailwindcss-stubs/resources/views/auth/login.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/login.blade.php
@@ -4,7 +4,7 @@
     <div class="container mx-auto">
         <div class="flex flex-wrap justify-center">
             <div class="w-full max-w-sm">
-                <div class="flex flex-col break-words bg-white border border-2 rounded shadow-md">
+                <div class="flex flex-col break-words bg-white border-2 rounded shadow-md">
 
                     <div class="font-semibold bg-gray-200 text-gray-700 py-3 px-6 mb-0">
                         {{ __('Login') }}

--- a/src/tailwindcss-stubs/resources/views/auth/passwords/confirm.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/passwords/confirm.blade.php
@@ -4,7 +4,7 @@
     <div class="container mx-auto">
         <div class="flex flex-wrap justify-center">
             <div class="w-full max-w-sm">
-                <div class="flex flex-col break-words bg-white border border-2 rounded shadow-md">
+                <div class="flex flex-col break-words bg-white border-2 rounded shadow-md">
 
                     <div class="font-semibold bg-gray-200 text-gray-700 py-3 px-6 mb-0">
                         {{ __('Confirm Password') }}

--- a/src/tailwindcss-stubs/resources/views/auth/passwords/email.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/passwords/email.blade.php
@@ -11,7 +11,7 @@
                     </div>
                 @endif
 
-                <div class="flex flex-col break-words bg-white border border-2 rounded shadow-md">
+                <div class="flex flex-col break-words bg-white border-2 rounded shadow-md">
 
                     <div class="font-semibold bg-gray-200 text-gray-700 py-3 px-6 mb-0">
                         {{ __('Reset Password') }}

--- a/src/tailwindcss-stubs/resources/views/auth/passwords/reset.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/passwords/reset.blade.php
@@ -4,7 +4,7 @@
     <div class="container mx-auto">
         <div class="flex flex-wrap justify-center">
             <div class="w-full max-w-sm">
-                <div class="flex flex-col break-words bg-white border border-2 rounded shadow-md">
+                <div class="flex flex-col break-words bg-white border-2 rounded shadow-md">
 
                     <div class="font-semibold bg-gray-200 text-gray-700 py-3 px-6 mb-0">
                         {{ __('Reset Password') }}

--- a/src/tailwindcss-stubs/resources/views/auth/register.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/register.blade.php
@@ -4,7 +4,7 @@
     <div class="container mx-auto">
         <div class="flex flex-wrap justify-center">
             <div class="w-full max-w-sm">
-                <div class="flex flex-col break-words bg-white border border-2 rounded shadow-md">
+                <div class="flex flex-col break-words bg-white border-2 rounded shadow-md">
 
                     <div class="font-semibold bg-gray-200 text-gray-700 py-3 px-6 mb-0">
                         {{ __('Register') }}

--- a/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
@@ -11,7 +11,7 @@
                     </div>
                 @endif
 
-                <div class="flex flex-col break-words bg-white border border-2 rounded shadow-md">
+                <div class="flex flex-col break-words bg-white border-2 rounded shadow-md">
                     <div class="font-semibold bg-gray-200 text-gray-700 py-3 px-6 mb-0">
                         {{ __('Verify Your Email Address') }}
                     </div>

--- a/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/verify.blade.php
@@ -22,7 +22,7 @@
                         </p>
 
                         <p class="leading-normal mt-6">
-                            {{ __('If you did not receive the email') }}, <a class="text-blue-500 hover:text-blue-700 no-underline" onclick="event.preventDefault(); document.getElementById('resend-verification-form').submit();">{{ __('click here to request another') }}</a>.
+                            {{ __('If you did not receive the email') }}, <a class="text-blue-500 hover:text-blue-700 no-underline cursor-pointer" onclick="event.preventDefault(); document.getElementById('resend-verification-form').submit();">{{ __('click here to request another') }}</a>.
                         </p>
 
                         <form id="resend-verification-form" method="POST" action="{{ route('verification.resend') }}" class="hidden">


### PR DESCRIPTION
Removing the base `border` class because it applies `border-width: 1-px` and immediately gets overwritten by `border-2` which applies `border-width: 2px`