### PR TITLE
Fixes bottom margin on login screen if registration is disabled.

### DIFF
--- a/src/tailwindcss-stubs/resources/views/auth/login.blade.php
+++ b/src/tailwindcss-stubs/resources/views/auth/login.blade.php
@@ -62,7 +62,7 @@
 
                     <div class="flex flex-wrap">
                         <button type="submit"
-                        class="w-full select-none font-bold whitespace-no-wrap p-3 rounded-lg text-base leading-normal no-underline text-gray-100 bg-blue-500 hover:bg-blue-700 sm:py-4">
+                        class="w-full select-none font-bold whitespace-no-wrap p-3 rounded-lg text-base leading-normal no-underline text-gray-100 bg-blue-500 hover:bg-blue-700 sm:py-4 {{ ! Route::has('register') ? 'mb-8' : '' }}">
                             {{ __('Login') }}
                         </button>
 


### PR DESCRIPTION
When the developer sets `Auth::routes(['register' => false]);` on `web.php` this is what login page looks like:

<img width="575" alt="Screen Shot 2020-12-19 at 1 34 09 PM" src="https://user-images.githubusercontent.com/17848299/102681798-70ced080-41ff-11eb-8542-187fbff85be2.png">

So I thought it could use a bit more bottom margin.